### PR TITLE
Rake task to restart spring

### DIFF
--- a/railties/lib/rails/tasks/restart.rake
+++ b/railties/lib/rails/tasks/restart.rake
@@ -1,0 +1,10 @@
+require 'spring/client'
+
+desc "Restart Rails and Spring"
+task :restart do
+  puts "Restarting Spring"
+  Spring::Client::Stop.call([])
+  # Quick hack to run spring.
+  Spring::Client::Run.call(["rake", "-e" "'puts'"])
+end
+


### PR DESCRIPTION
This rake task would restart **Spring** with out expanding its watch list. related to #18874 and #18876
